### PR TITLE
feat: 프로젝트 상세 모달 UI 개선(#76)

### DIFF
--- a/src/components/projects/ImageViewerModal.tsx
+++ b/src/components/projects/ImageViewerModal.tsx
@@ -81,13 +81,13 @@ export default function ImageViewerModal({
           </h2>
           {/* Close Button */}
           <motion.button
-            className="absolute top-4 right-4 z-20 cursor-pointer rounded-full bg-white/90 p-3 shadow-lg transition-all hover:bg-white hover:shadow-xl"
+            className="absolute top-5 right-5 z-20 flex h-12 w-12 cursor-pointer items-center justify-center rounded-2xl border border-white/34 bg-white/24 text-white shadow-[inset_0_0_0_1px_rgba(255,255,255,0.28),0_14px_40px_rgba(15,23,42,0.24)] backdrop-blur-xl transition-all hover:border-white/42 hover:bg-white/30 focus-visible:ring-2 focus-visible:ring-white/75 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 focus-visible:outline-none sm:top-6 sm:right-6"
             onClick={onClose}
-            whileHover={{ scale: 1.1 }}
-            whileTap={{ scale: 0.9 }}
+            whileHover={{ scale: 1.04 }}
+            whileTap={{ scale: 0.96 }}
             aria-label="이미지 뷰어 닫기"
           >
-            <RiCloseLine className="text-2xl text-gray-700" />
+            <RiCloseLine className="text-2xl" />
           </motion.button>
 
           {/* Image Slider */}
@@ -110,16 +110,15 @@ export default function ImageViewerModal({
                 singleImageHeight="h-full max-h-[90vh]"
                 containerClassName="h-full w-full"
               />
-
-              {/* Navigation Buttons (only for multiple images) */}
-              {images.length > 1 && (
-                <SwiperNavigationButtons
-                  prevButtonId="viewer-prev"
-                  nextButtonId="viewer-next"
-                  variant="viewer"
-                />
-              )}
             </div>
+            {/* Navigation Buttons (only for multiple images) */}
+            {images.length > 1 && (
+              <SwiperNavigationButtons
+                prevButtonId="viewer-prev"
+                nextButtonId="viewer-next"
+                variant="viewer"
+              />
+            )}
           </div>
 
           {/* Image Counter */}

--- a/src/components/projects/ImageViewerModal.tsx
+++ b/src/components/projects/ImageViewerModal.tsx
@@ -106,6 +106,7 @@ export default function ImageViewerModal({
                 spaceBetween={20}
                 imageClassName="object-contain"
                 mode="viewer"
+                showPagination={false}
                 singleImageHeight="h-full max-h-[90vh]"
                 containerClassName="h-full w-full"
               />

--- a/src/components/projects/ProjectContributions.tsx
+++ b/src/components/projects/ProjectContributions.tsx
@@ -26,15 +26,15 @@ export default function ProjectContributions({
 
   return (
     <motion.div
-      className="mb-8"
+      className=""
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 0.6 }}
     >
-      <h2 className="mb-4 text-2xl font-bold text-gray-900">
+      <h2 className="mb-4 text-xl font-semibold text-gray-950">
         {t('projects_modal.contributions')}
       </h2>
-      <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2">
         {contributions.map((contribution, index) => {
           const title =
             i18n.language.startsWith('en') && contribution.titleEn
@@ -44,15 +44,15 @@ export default function ProjectContributions({
           return (
             <motion.div
               key={index}
-              className="rounded-lg border border-gray-200 bg-gray-50 p-6"
+              className="rounded-3xl border border-gray-200 bg-white p-5"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.7 + index * 0.1 }}
             >
-              <h3 className="mb-3 text-lg font-semibold text-gray-900">
+              <h3 className="mb-3 text-base font-semibold text-gray-950">
                 {title}
               </h3>
-              <div className="space-y-2">
+              <div className="space-y-3">
                 {contribution.details.map((detail, detailIndex) => {
                   const text =
                     i18n.language.startsWith('en') && detail.textEn
@@ -66,14 +66,14 @@ export default function ProjectContributions({
                   return (
                     <div key={detailIndex} className="flex items-start gap-3">
                       <div className="bg-seagull-500 mt-2 h-1.5 w-1.5 shrink-0 rounded-full" />
-                      <div className="text-sm text-gray-600">
+                      <div className="text-sm leading-6 text-gray-600">
                         <span>{text}</span>
                         {detail.link && (
                           <a
                             href={detail.link}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="bg-seagull-100 text-seagull-700 hover:bg-seagull-200 ml-2 inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium transition-colors"
+                            className="text-seagull-700 hover:text-seagull-800 bg-seagull-50 hover:bg-seagull-100 ml-2 inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-semibold transition-colors"
                           >
                             <FaExternalLinkAlt className="h-2 w-2" />
                             {linkText || t('projects_modal.link')}

--- a/src/components/projects/ProjectDetailModal.tsx
+++ b/src/components/projects/ProjectDetailModal.tsx
@@ -93,30 +93,30 @@ export default function ProjectDetailModal({
           transition={{ duration: 0.2 }}
         >
           <motion.div
-            className="fixed top-0 left-0 z-60 size-full cursor-pointer bg-black/50"
+            className="fixed top-0 left-0 z-60 size-full cursor-pointer bg-gray-950/45 backdrop-blur-sm"
             onClick={handleBackdropClick}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
           />
-          <div className="fixed top-1/2 left-1/2 z-70 max-h-[95vh] w-[95vw] max-w-6xl -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl">
+          <div className="fixed top-1/2 left-1/2 z-70 max-h-[92vh] w-[94vw] max-w-6xl -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-3xl">
             <motion.div
               ref={modalRef}
               role="dialog"
               aria-modal="true"
               aria-labelledby="modal-title"
               aria-describedby="modal-description"
-              className="relative bg-white shadow-2xl"
-              initial={{ opacity: 0, scale: 0.8, y: 20 }}
+              className="relative border border-gray-200 bg-white shadow-xl shadow-gray-950/10"
+              initial={{ opacity: 0, scale: 0.96, y: 20 }}
               animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.8, y: 20 }}
+              exit={{ opacity: 0, scale: 0.96, y: 20 }}
               transition={{ duration: 0.3, ease: 'easeOut' }}
               onClick={(e) => e.stopPropagation()}
             >
               {/* Close Button - 고정 */}
               <motion.button
                 ref={closeButtonRef}
-                className="absolute top-4 right-4 z-10 cursor-pointer rounded-full bg-white/90 p-2 shadow-md transition-colors hover:bg-gray-100"
+                className="focus-visible:ring-seagull-200 absolute top-4 right-4 z-10 inline-flex size-10 cursor-pointer items-center justify-center rounded-2xl bg-white/90 text-gray-500 shadow-sm ring-1 ring-gray-200 backdrop-blur transition-colors hover:bg-gray-50 hover:text-gray-900 focus-visible:ring-2 focus-visible:outline-none"
                 onClick={closeModal}
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.9 }}
@@ -126,46 +126,39 @@ export default function ProjectDetailModal({
               </motion.button>
 
               {/* Project Content - 전체 스크롤 */}
-              <div className="max-h-[95vh] overflow-y-auto">
+              <div className="max-h-[92vh] overflow-y-auto">
                 {/* Project Header */}
-                <div className="relative h-80 w-full overflow-hidden">
+                <div className="relative m-2 h-72 overflow-hidden rounded-3xl sm:h-80">
                   <Image
-                    src={project.image}
+                    src={project.image || '/images/common/img_user.png'}
                     alt={title}
                     fill
                     className="object-cover"
                     priority
                   />
-                  <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/20 to-transparent" />
-
-                  {/* Category Badge */}
-                  <motion.div
-                    className="absolute top-4 left-4"
-                    initial={{ opacity: 0, scale: 0.8 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    transition={{ delay: 0.2 }}
-                  >
-                    <span className="rounded-full bg-white/90 px-3 py-1 text-sm font-medium text-gray-700">
-                      {project.category}
-                    </span>
-                  </motion.div>
+                  <div className="absolute inset-0 bg-linear-to-t from-gray-950/75 via-gray-950/20 to-transparent" />
 
                   {/* Project Title */}
                   <motion.div
-                    className="absolute right-6 bottom-6 left-6"
+                    className="absolute right-5 bottom-5 left-5 sm:right-8 sm:bottom-8 sm:left-8"
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.3 }}
                   >
                     <h1
                       id="modal-title"
-                      className="mb-2 text-3xl font-bold text-white"
+                      className="mb-3 max-w-4xl text-3xl leading-tight font-semibold text-white sm:text-4xl"
                     >
                       {title}
                     </h1>
+                    <div className="mb-3 flex items-center gap-2">
+                      <span className="rounded-xl bg-white/15 px-3 py-1 text-xs font-semibold tracking-[0.08em] text-white/80 uppercase backdrop-blur">
+                        {project.category}
+                      </span>
+                    </div>
                     <p
                       id="modal-description"
-                      className="text-lg leading-relaxed text-white/90"
+                      className="max-w-3xl text-base leading-relaxed text-white/85 sm:text-lg"
                     >
                       {description}
                     </p>
@@ -173,19 +166,19 @@ export default function ProjectDetailModal({
                 </div>
 
                 {/* Project Content */}
-                <div className="p-8">
+                <div className="space-y-10 px-5 pt-6 pb-8 sm:px-8">
                   {/* Overview Section */}
                   {overview && (
                     <motion.div
-                      className="mb-8"
+                      className="rounded-3xl bg-gray-50 p-5 sm:p-6"
                       initial={{ opacity: 0, y: 20 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ delay: 0.4 }}
                     >
-                      <h2 className="mb-4 text-2xl font-bold text-gray-900">
+                      <h2 className="mb-3 text-xl font-semibold text-gray-950">
                         {t('projects_modal.overview')}
                       </h2>
-                      <p className="text-lg leading-relaxed text-gray-600">
+                      <p className="text-base leading-8 text-gray-600">
                         {overview}
                       </p>
                     </motion.div>
@@ -194,26 +187,26 @@ export default function ProjectDetailModal({
                   {/* Features Section */}
                   {features.length > 0 && (
                     <motion.div
-                      className="mb-8"
+                      className="rounded-3xl border border-gray-200 p-5 sm:p-6"
                       initial={{ opacity: 0, y: 20 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ delay: 0.5 }}
                     >
-                      <h2 className="mb-4 text-2xl font-bold text-gray-900">
+                      <h2 className="mb-4 text-xl font-semibold text-gray-950">
                         {t('projects_modal.features')}
                       </h2>
-                      <div className="grid gap-3">
+                      <div className="grid gap-3 sm:grid-cols-2">
                         {features.map((feature, index) => (
                           <motion.div
                             key={index}
-                            className="flex items-start gap-3"
+                            className="flex items-start gap-3 rounded-2xl bg-gray-50 px-4 py-3"
                             initial={{ opacity: 0, x: -20 }}
                             animate={{ opacity: 1, x: 0 }}
                             transition={{ delay: 0.6 + index * 0.1 }}
                           >
-                            <div className="bg-seagull-500 mt-2 h-2 w-2 shrink-0 rounded-full" />
+                            <div className="bg-seagull-500 mt-2 h-1.5 w-1.5 shrink-0 rounded-full" />
                             <span
-                              className="text-gray-600"
+                              className="text-sm leading-6 text-gray-600"
                               dangerouslySetInnerHTML={{
                                 __html: feature.replace(
                                   /\*\*(.*?)\*\*/g,
@@ -237,42 +230,42 @@ export default function ProjectDetailModal({
                   {/* Project Info Grid */}
                   {project.detail && (
                     <motion.div
-                      className="mb-8"
+                      className=""
                       initial={{ opacity: 0, y: 20 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ delay: 0.8 }}
                     >
-                      <h2 className="mb-4 text-2xl font-bold text-gray-900">
+                      <h2 className="mb-4 text-xl font-semibold text-gray-950">
                         {t('projects_modal.info')}
                       </h2>
                       <div className="grid gap-6 md:grid-cols-2">
                         {/* Timeline */}
-                        <div className="rounded-lg bg-gray-50 p-4">
-                          <h3 className="mb-3 font-semibold text-gray-900">
+                        <div className="rounded-3xl bg-gray-50 p-5">
+                          <h3 className="mb-4 text-base font-semibold text-gray-950">
                             {t('projects_modal.timeline')}
                           </h3>
-                          <div className="space-y-2">
-                            <div className="flex justify-between">
-                              <span className="text-gray-600">
+                          <div className="space-y-3">
+                            <div className="flex items-center justify-between gap-4">
+                              <span className="text-sm text-gray-500">
                                 {t('projects_modal.start')}
                               </span>
-                              <span className="font-medium">
+                              <span className="text-sm font-semibold text-gray-800">
                                 {project.detail?.timeline?.startDate || '-'}
                               </span>
                             </div>
-                            <div className="flex justify-between">
-                              <span className="text-gray-600">
+                            <div className="flex items-center justify-between gap-4">
+                              <span className="text-sm text-gray-500">
                                 {t('projects_modal.end')}
                               </span>
-                              <span className="font-medium">
+                              <span className="text-sm font-semibold text-gray-800">
                                 {project.detail?.timeline?.endDate || '-'}
                               </span>
                             </div>
-                            <div className="flex justify-between">
-                              <span className="text-gray-600">
+                            <div className="flex items-center justify-between gap-4">
+                              <span className="text-sm text-gray-500">
                                 {t('projects_modal.duration')}
                               </span>
-                              <span className="font-medium">
+                              <span className="text-sm font-semibold text-gray-800">
                                 {project.detail?.timeline?.duration || '-'}
                               </span>
                             </div>
@@ -280,45 +273,47 @@ export default function ProjectDetailModal({
                         </div>
 
                         {/* Team Info */}
-                        <div className="rounded-lg bg-gray-50 p-4">
-                          <h3 className="mb-3 font-semibold text-gray-900">
+                        <div className="rounded-3xl bg-gray-50 p-5">
+                          <h3 className="mb-4 text-base font-semibold text-gray-950">
                             {t('projects_modal.team_info')}
                           </h3>
-                          <div className="space-y-2">
-                            <div className="flex justify-between">
-                              <span className="text-gray-600">
+                          <div className="space-y-3">
+                            <div className="flex items-center justify-between gap-4">
+                              <span className="text-sm text-gray-500">
                                 {t('projects_modal.team_size')}:
                               </span>
-                              <span className="font-medium">
+                              <span className="text-sm font-semibold text-gray-800">
                                 {project.detail?.team?.size || 1}{' '}
                                 {t('projects_modal.team_unit')}
                               </span>
                             </div>
-                            <div className="flex justify-between">
-                              <span className="text-gray-600">역할:</span>
-                              <span className="font-medium">
+                            <div className="flex items-center justify-between gap-4">
+                              <span className="text-sm text-gray-500">
+                                {t('projects_modal.role')}:
+                              </span>
+                              <span className="text-right text-sm font-semibold text-gray-800">
                                 {role || '-'}
                               </span>
                             </div>
                           </div>
                           {responsibilities.length > 0 && (
-                              <div className="mt-3 border-t border-gray-200 pt-3">
-                                <h4 className="mb-2 text-sm font-semibold text-gray-700">
-                                  {t('projects_modal.responsibilities')}
-                                </h4>
-                                <ul className="space-y-1">
-                                  {responsibilities.map((resp, index) => (
-                                    <li
-                                      key={index}
-                                      className="flex items-start gap-2 text-sm text-gray-600"
-                                    >
-                                      <span className="bg-seagull-500 mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full" />
-                                      {resp}
-                                    </li>
-                                  ))}
-                                </ul>
-                              </div>
-                            )}
+                            <div className="mt-4 border-t border-gray-200 pt-4">
+                              <h4 className="mb-2 text-sm font-semibold text-gray-700">
+                                {t('projects_modal.responsibilities')}
+                              </h4>
+                              <ul className="space-y-2">
+                                {responsibilities.map((resp, index) => (
+                                  <li
+                                    key={index}
+                                    className="flex items-start gap-2 text-sm leading-6 text-gray-600"
+                                  >
+                                    <span className="bg-seagull-500 mt-2 h-1.5 w-1.5 shrink-0 rounded-full" />
+                                    {resp}
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
                         </div>
                       </div>
                     </motion.div>
@@ -328,12 +323,12 @@ export default function ProjectDetailModal({
                   {project.detail?.images &&
                     project.detail.images.length > 0 && (
                       <motion.div
-                        className="mb-8"
+                        className=""
                         initial={{ opacity: 0, y: 20 }}
                         animate={{ opacity: 1, y: 0 }}
                         transition={{ delay: 0.85 }}
                       >
-                        <h2 className="mb-4 text-2xl font-bold text-gray-900">
+                        <h2 className="mb-4 text-xl font-semibold text-gray-950">
                           {t('projects_modal.images')}
                         </h2>
                         <ProjectImageSlider
@@ -348,63 +343,69 @@ export default function ProjectDetailModal({
                     )}
 
                   {/* Challenges & Results */}
-                  {project.detail && (
-                    <div className="mb-8 grid gap-8 md:grid-cols-2">
+                  {(challenges.length > 0 || results.length > 0) && (
+                    <div className="grid gap-6 md:grid-cols-2">
                       {/* Challenges */}
-                      <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: 0.9 }}
-                      >
-                        <h2 className="mb-4 text-2xl font-bold text-gray-900">
-                          {t('projects_modal.challenges')}
-                        </h2>
-                        <div className="space-y-3">
-                          {challenges.map((challenge, index) => (
-                            <motion.div
-                              key={index}
-                              className="flex items-start gap-3"
-                              initial={{ opacity: 0, x: -20 }}
-                              animate={{ opacity: 1, x: 0 }}
-                              transition={{ delay: 1.0 + index * 0.1 }}
-                            >
-                              <div className="mt-2 h-2 w-2 shrink-0 rounded-full bg-orange-500" />
-                              <span className="text-gray-600">{challenge}</span>
-                            </motion.div>
-                          ))}
-                        </div>
-                      </motion.div>
+                      {challenges.length > 0 && (
+                        <motion.div
+                          initial={{ opacity: 0, y: 20 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          transition={{ delay: 0.9 }}
+                        >
+                          <h2 className="mb-4 text-xl font-semibold text-gray-950">
+                            {t('projects_modal.challenges')}
+                          </h2>
+                          <div className="space-y-2 rounded-3xl bg-gray-50 p-5">
+                            {challenges.map((challenge, index) => (
+                              <motion.div
+                                key={index}
+                                className="flex items-start gap-3 text-sm leading-6"
+                                initial={{ opacity: 0, x: -20 }}
+                                animate={{ opacity: 1, x: 0 }}
+                                transition={{ delay: 1.0 + index * 0.1 }}
+                              >
+                                <div className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-400" />
+                                <span className="text-gray-600">
+                                  {challenge}
+                                </span>
+                              </motion.div>
+                            ))}
+                          </div>
+                        </motion.div>
+                      )}
 
                       {/* Results */}
-                      <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: 1.1 }}
-                      >
-                        <h2 className="mb-4 text-2xl font-bold text-gray-900">
-                          {t('projects_modal.results')}
-                        </h2>
-                        <div className="space-y-3">
-                          {results.map((result, index) => (
-                            <motion.div
-                              key={index}
-                              className="flex items-start gap-3"
-                              initial={{ opacity: 0, x: -20 }}
-                              animate={{ opacity: 1, x: 0 }}
-                              transition={{ delay: 1.2 + index * 0.1 }}
-                            >
-                              <div className="mt-2 h-2 w-2 shrink-0 rounded-full bg-green-500" />
-                              <span className="text-gray-600">{result}</span>
-                            </motion.div>
-                          ))}
-                        </div>
-                      </motion.div>
+                      {results.length > 0 && (
+                        <motion.div
+                          initial={{ opacity: 0, y: 20 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          transition={{ delay: 1.1 }}
+                        >
+                          <h2 className="mb-4 text-xl font-semibold text-gray-950">
+                            {t('projects_modal.results')}
+                          </h2>
+                          <div className="space-y-2 rounded-3xl bg-gray-50 p-5">
+                            {results.map((result, index) => (
+                              <motion.div
+                                key={index}
+                                className="flex items-start gap-3 text-sm leading-6"
+                                initial={{ opacity: 0, x: -20 }}
+                                animate={{ opacity: 1, x: 0 }}
+                                transition={{ delay: 1.2 + index * 0.1 }}
+                              >
+                                <div className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-green-400" />
+                                <span className="text-gray-600">{result}</span>
+                              </motion.div>
+                            ))}
+                          </div>
+                        </motion.div>
+                      )}
                     </div>
                   )}
 
                   {/* Project Links */}
                   <motion.div
-                    className="flex flex-wrap gap-4"
+                    className="flex flex-wrap gap-3 border-t border-gray-100 pt-6"
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 1.3 }}
@@ -413,7 +414,7 @@ export default function ProjectDetailModal({
                       href={project.githubUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="flex items-center gap-2 rounded-lg bg-gray-900 px-6 py-3 text-white transition-colors hover:bg-gray-800"
+                      className="inline-flex min-h-11 items-center gap-2 rounded-2xl bg-gray-950 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:outline-none"
                     >
                       <FaGithub className="text-lg" />
                       <span>{t('projects_modal.github')}</span>
@@ -423,7 +424,7 @@ export default function ProjectDetailModal({
                         href={project.liveUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="bg-seagull-500 hover:bg-seagull-600 flex items-center gap-2 rounded-lg px-6 py-3 text-white transition-colors"
+                        className="bg-seagull-500 hover:bg-seagull-600 focus-visible:ring-seagull-200 inline-flex min-h-11 items-center gap-2 rounded-2xl px-5 py-3 text-sm font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:outline-none"
                       >
                         <FaExternalLinkAlt className="text-lg" />
                         <span>{t('projects_modal.live')}</span>

--- a/src/components/projects/ProjectTechStack.tsx
+++ b/src/components/projects/ProjectTechStack.tsx
@@ -35,25 +35,25 @@ export default function ProjectTechStack({ techStack }: ProjectTechStackProps) {
 
   return (
     <motion.div
-      className="mb-8"
+      className=""
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 0.7 }}
     >
-      <h2 className="mb-4 text-2xl font-bold text-gray-900">
+      <h2 className="mb-4 text-xl font-semibold text-gray-950">
         {t('projects_modal.tech_stack')}
       </h2>
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {Object.entries(techStack).map(([category, techs]) => (
-          <div key={category} className="rounded-lg bg-gray-50 p-4">
-            <h3 className="mb-2 font-semibold text-gray-900 capitalize">
+          <div key={category} className="rounded-3xl bg-gray-50 p-5">
+            <h3 className="mb-3 text-sm font-semibold text-gray-950 capitalize">
               {categoryLabels[category] || category}
             </h3>
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-1.5">
               {techs?.map((tech, index) => (
                 <span
                   key={index}
-                  className="bg-seagull-100 text-seagull-800 rounded-full px-3 py-1 text-sm font-medium"
+                  className="rounded-lg bg-white px-2 py-1 text-xs font-medium text-gray-500"
                 >
                   {tech}
                 </span>

--- a/src/components/projects/swiper/ImageCounter.tsx
+++ b/src/components/projects/swiper/ImageCounter.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { Swiper as SwiperType } from 'swiper';
+import { useEffect, useState } from 'react';
 
 interface ImageCounterProps {
   swiperInstance: SwiperType | null;
@@ -15,11 +16,30 @@ export default function ImageCounter({
   totalImages,
   className = '',
 }: ImageCounterProps) {
-  if (totalImages <= 1) return null;
+  const [displayIndex, setDisplayIndex] = useState(currentIndex + 1);
 
-  const displayIndex = swiperInstance
-    ? swiperInstance.activeIndex + 1
-    : currentIndex + 1;
+  useEffect(() => {
+    setDisplayIndex(currentIndex + 1);
+  }, [currentIndex]);
+
+  useEffect(() => {
+    if (!swiperInstance) return;
+
+    const updateIndex = () => {
+      setDisplayIndex(swiperInstance.realIndex + 1);
+    };
+
+    updateIndex();
+    swiperInstance.on('slideChange', updateIndex);
+    swiperInstance.on('realIndexChange', updateIndex);
+
+    return () => {
+      swiperInstance.off('slideChange', updateIndex);
+      swiperInstance.off('realIndexChange', updateIndex);
+    };
+  }, [swiperInstance]);
+
+  if (totalImages <= 1) return null;
 
   return (
     <div
@@ -29,4 +49,3 @@ export default function ImageCounter({
     </div>
   );
 }
-

--- a/src/components/projects/swiper/ImageSwiper.tsx
+++ b/src/components/projects/swiper/ImageSwiper.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Image from 'next/image';
-import { useState } from 'react';
 import type { Swiper as SwiperType } from 'swiper';
 import { A11y, Navigation, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -22,6 +21,7 @@ interface ImageSwiperProps {
     prevEl: string;
     nextEl: string;
   };
+  showPagination?: boolean;
   // 스타일 옵션
   imageClassName?: string;
   containerClassName?: string;
@@ -39,16 +39,14 @@ export default function ImageSwiper({
   slidesPerView = 1,
   spaceBetween = 16,
   navigation,
+  showPagination = true,
   imageClassName = 'object-cover',
   containerClassName = '',
   singleImageHeight = 'h-64 md:h-96',
   mode = 'thumbnail',
 }: ImageSwiperProps) {
-  const [swiperInstance, setSwiperInstance] = useState<SwiperType | null>(null);
-
   // Swiper 인스턴스 설정
   const handleSwiper = (swiper: SwiperType) => {
-    setSwiperInstance(swiper);
     onSwiper?.(swiper);
 
     // initialIndex가 있으면 해당 슬라이드로 이동
@@ -97,14 +95,16 @@ export default function ImageSwiper({
 
   // Swiper 설정
   const swiperConfig = {
-    modules: [Navigation, Pagination, A11y],
+    modules: [Navigation, ...(showPagination ? [Pagination] : []), A11y],
     slidesPerView: typeof slidesPerView === 'number' ? slidesPerView : 1,
     spaceBetween: typeof spaceBetween === 'number' ? spaceBetween : 16,
     navigation: navigation || undefined,
-    pagination: {
-      clickable: true,
-      dynamicBullets: true,
-    },
+    pagination: showPagination
+      ? {
+          clickable: true,
+          dynamicBullets: true,
+        }
+      : false,
     loop: images.length > 1, // 이미지가 2개 이상일 때만 loop 활성화
     onSwiper: handleSwiper,
     a11y: {

--- a/src/components/projects/swiper/SwiperNavigationButtons.tsx
+++ b/src/components/projects/swiper/SwiperNavigationButtons.tsx
@@ -15,57 +15,38 @@ export default function SwiperNavigationButtons({
   variant = 'default',
   className = '',
 }: SwiperNavigationButtonsProps) {
-  const baseClasses =
-    'absolute top-1/2 z-10 -translate-y-1/2 rounded-full bg-white/90 p-2 shadow-lg transition-all hover:bg-white hover:shadow-xl cursor-pointer';
-  const viewerClasses = variant === 'viewer' ? 'p-3 z-20' : '';
+  const isViewer = variant === 'viewer';
+  const baseClasses = isViewer
+    ? 'absolute top-1/2 z-30 -translate-y-1/2 cursor-pointer transition-all focus-visible:outline-none'
+    : 'absolute top-1/2 z-10 -translate-y-1/2 cursor-pointer transition-all focus-visible:outline-none';
+  const buttonClasses = isViewer
+    ? 'flex h-12 w-12 items-center justify-center rounded-2xl border border-white/34 bg-white/24 text-white shadow-[inset_0_0_0_1px_rgba(255,255,255,0.28),0_14px_42px_rgba(15,23,42,0.26)] backdrop-blur-xl hover:border-white/56 hover:bg-white/48 hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.42),0_18px_52px_rgba(15,23,42,0.3)] focus-visible:ring-2 focus-visible:ring-white/75 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 sm:h-14 sm:w-14'
+    : 'rounded-full bg-white/90 p-2 text-gray-700 shadow-lg hover:bg-white hover:shadow-xl focus-visible:ring-2 focus-visible:ring-seagull-400 focus-visible:ring-offset-2';
+  const iconClasses = isViewer
+    ? 'text-3xl transition-transform'
+    : 'text-2xl text-gray-700';
+  const prevPosition = isViewer ? 'left-4 sm:left-6' : 'left-4';
+  const nextPosition = isViewer ? 'right-4 sm:right-6' : 'right-4';
 
   return (
     <>
       <button
         id={prevButtonId}
-        className={`${baseClasses} ${viewerClasses} left-4 ${className}`}
+        className={`${baseClasses} ${buttonClasses} ${prevPosition} group ${className}`}
         aria-label="이전 이미지"
       >
-        {variant === 'viewer' ? (
-          <svg
-            className="h-6 w-6 text-gray-700"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M15 19l-7-7 7-7"
-            />
-          </svg>
-        ) : (
-          <GoChevronLeft className="text-2xl text-gray-700" />
-        )}
+        <GoChevronLeft
+          className={`${iconClasses} ${isViewer ? 'group-hover:-translate-x-0.5' : ''}`}
+        />
       </button>
       <button
         id={nextButtonId}
-        className={`${baseClasses} ${viewerClasses} right-4 ${className}`}
+        className={`${baseClasses} ${buttonClasses} ${nextPosition} group ${className}`}
         aria-label="다음 이미지"
       >
-        {variant === 'viewer' ? (
-          <svg
-            className="h-6 w-6 text-gray-700"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 5l7 7-7 7"
-            />
-          </svg>
-        ) : (
-          <GoChevronRight className="text-2xl text-gray-700" />
-        )}
+        <GoChevronRight
+          className={`${iconClasses} ${isViewer ? 'group-hover:translate-x-0.5' : ''}`}
+        />
       </button>
     </>
   );


### PR DESCRIPTION
## 관련 이슈

- Closes #76
- Related to #74

## 변경 사항

- [ ] 버그 수정
- [ ] 새로운 기능 추가
- [x] 기존 기능 개선
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명 필요)

## 상세 설명

- 프로젝트 상세 모달의 헤더, 본문 섹션, 정보 카드 레이아웃을 부드러운 제품 UI 톤으로 개선했습니다.
- 기여 섹션과 기술 스택 섹션의 카드/칩 스타일을 정리했습니다.
- 이미지 뷰어의 페이지 카운터를 실제 슬라이드 기준으로 보정하고 dot pagination을 제거했습니다.
- 이미지 뷰어 닫기/좌우 컨트롤을 glass 스타일로 다듬고 hover/focus 상태를 개선했습니다.

## 테스트

- [x] 로컬에서 테스트 완료
- [ ] 새로운 테스트 케이스 추가 (필요한 경우)
- [x] 기존 테스트 통과 확인

검증 명령:

- `npx prettier --check src/components/projects/ImageViewerModal.tsx src/components/projects/swiper/ImageSwiper.tsx src/components/projects/swiper/ImageCounter.tsx src/components/projects/swiper/SwiperNavigationButtons.tsx`
- `npx eslint src/components/projects/ProjectDetailModal.tsx src/components/projects/ProjectContributions.tsx src/components/projects/ProjectTechStack.tsx src/components/projects/ImageViewerModal.tsx src/components/projects/swiper/ImageSwiper.tsx src/components/projects/swiper/ImageCounter.tsx src/components/projects/swiper/SwiperNavigationButtons.tsx`
- `npx tsc --noEmit`

## 스크린샷

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->