### PR TITLE
feat: 관리자 프로젝트 폼 UI 개선 (#77)

### DIFF
--- a/src/app/[lang]/admin/projects/page.tsx
+++ b/src/app/[lang]/admin/projects/page.tsx
@@ -10,21 +10,42 @@ export default function AdminProjectsPage() {
   const [editingProject, setEditingProject] = useState<FirebaseProject | null>(
     null
   );
+  const [notice, setNotice] = useState<string | null>(null);
 
   return (
-    <div className="p-8">
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-3xl font-bold">프로젝트 관리</h1>
+    <div className="p-4 sm:p-6 lg:p-8">
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-seagull-700 mb-1 text-sm font-semibold">
+            Portfolio Admin
+          </p>
+          <h1 className="text-2xl font-bold text-gray-950 sm:text-3xl">
+            프로젝트 관리
+          </h1>
+          <p className="mt-2 text-sm leading-6 break-keep text-gray-500">
+            포트폴리오에 노출할 프로젝트를 등록하고 관리합니다.
+          </p>
+        </div>
         <button
           onClick={() => {
             setEditingProject(null);
+            setNotice(null);
             setShowForm(true);
           }}
-          className="bg-seagull-500 hover:bg-seagull-600 cursor-pointer rounded-lg px-6 py-2 text-white transition"
+          className="bg-seagull-500 hover:bg-seagull-600 focus-visible:ring-seagull-200 min-h-11 w-full rounded-xl px-5 py-2.5 text-sm font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:outline-none sm:w-auto"
         >
           + 새 프로젝트
         </button>
       </div>
+
+      {notice && !showForm && (
+        <div
+          role="status"
+          className="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-medium break-keep text-emerald-800"
+        >
+          {notice}
+        </div>
+      )}
 
       {showForm ? (
         <ProjectForm
@@ -34,6 +55,11 @@ export default function AdminProjectsPage() {
             setEditingProject(null);
           }}
           onSuccess={() => {
+            setNotice(
+              editingProject
+                ? '프로젝트를 수정했습니다.'
+                : '새 프로젝트를 등록했습니다.'
+            );
             setShowForm(false);
             setEditingProject(null);
           }}
@@ -41,6 +67,7 @@ export default function AdminProjectsPage() {
       ) : (
         <ProjectList
           onEdit={(project) => {
+            setNotice(null);
             setEditingProject(project);
             setShowForm(true);
           }}

--- a/src/components/admin/project/FormField.tsx
+++ b/src/components/admin/project/FormField.tsx
@@ -12,6 +12,8 @@ interface FormFieldProps {
   required?: boolean;
   validation?: object;
   className?: string;
+  optional?: boolean;
+  language?: 'ko' | 'en';
 }
 
 export default function FormField({
@@ -22,6 +24,8 @@ export default function FormField({
   required = false,
   validation = {},
   className,
+  optional = false,
+  language = 'ko',
 }: FormFieldProps) {
   const {
     register,
@@ -36,16 +40,31 @@ export default function FormField({
 
   return (
     <div className={className}>
-      <label className="mb-2 block text-sm font-medium">
-        {label} {required && <span className="text-red-500">*</span>}
+      <label className="mb-2 flex items-center gap-2 text-sm font-semibold text-gray-800">
+        <span>{label}</span>
+        {required && (
+          <span className="text-xs font-medium text-red-600">필수</span>
+        )}
+        {optional && (
+          <span className="text-xs font-medium text-gray-400">선택</span>
+        )}
+        {language === 'en' && (
+          <span className="rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-gray-500">
+            EN
+          </span>
+        )}
       </label>
       <Input
         type={type}
         {...register(name, rules)}
         placeholder={placeholder}
+        aria-invalid={Boolean(error)}
+        className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
       />
       {error && (
-        <p className="mt-1 text-xs text-red-500">{String(error?.message)}</p>
+        <p className="mt-1.5 text-xs font-medium text-red-600" role="alert">
+          {String(error?.message)}
+        </p>
       )}
     </div>
   );

--- a/src/components/admin/project/FormTextarea.tsx
+++ b/src/components/admin/project/FormTextarea.tsx
@@ -10,6 +10,8 @@ interface FormTextareaProps {
   validation?: object;
   rows?: number;
   className?: string;
+  optional?: boolean;
+  language?: 'ko' | 'en';
 }
 
 export default function FormTextarea({
@@ -20,6 +22,8 @@ export default function FormTextarea({
   validation = {},
   rows = 4,
   className,
+  optional = false,
+  language = 'ko',
 }: FormTextareaProps) {
   const {
     register,
@@ -34,17 +38,31 @@ export default function FormTextarea({
 
   return (
     <div className={className}>
-      <label className="mb-2 block text-sm font-medium">
-        {label} {required && <span className="text-red-500">*</span>}
+      <label className="mb-2 flex items-center gap-2 text-sm font-semibold text-gray-800">
+        <span>{label}</span>
+        {required && (
+          <span className="text-xs font-medium text-red-600">필수</span>
+        )}
+        {optional && (
+          <span className="text-xs font-medium text-gray-400">선택</span>
+        )}
+        {language === 'en' && (
+          <span className="rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-gray-500">
+            EN
+          </span>
+        )}
       </label>
       <textarea
         {...register(name, rules)}
         rows={rows}
         placeholder={placeholder}
-        className="focus:border-seagull-500 w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none"
+        aria-invalid={Boolean(error)}
+        className="focus:border-seagull-500 focus:ring-seagull-100 w-full resize-y rounded-xl border border-gray-300 px-4 py-3 leading-6 transition-colors focus:ring-2 focus:outline-none"
       />
       {error && (
-        <p className="mt-1 text-xs text-red-500">{String(error?.message)}</p>
+        <p className="mt-1.5 text-xs font-medium text-red-600" role="alert">
+          {String(error?.message)}
+        </p>
       )}
     </div>
   );

--- a/src/components/admin/project/ProjectForm.tsx
+++ b/src/components/admin/project/ProjectForm.tsx
@@ -25,6 +25,7 @@ export default function ProjectForm({
 }: ProjectFormProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const methods = useForm({
     defaultValues: {
@@ -64,6 +65,7 @@ export default function ProjectForm({
 
   const onSubmit = async (data: Partial<FirebaseProject>) => {
     setLoading(true);
+    setSubmitError(null);
 
     try {
       const formDataToSend = new FormData();
@@ -96,14 +98,14 @@ export default function ProjectForm({
         onSuccess();
         router.refresh();
       } else {
-        alert(
+        setSubmitError(
           editingProject
             ? '프로젝트 수정에 실패했습니다.'
             : '프로젝트 등록에 실패했습니다.'
         );
       }
     } catch {
-      alert(
+      setSubmitError(
         editingProject
           ? '프로젝트 수정 중 오류가 발생했습니다.'
           : '프로젝트 등록 중 오류가 발생했습니다.'
@@ -153,6 +155,15 @@ export default function ProjectForm({
           </ProjectFormSection>
 
           <ProjectFormDetailInfo />
+
+          {submitError && (
+            <div
+              role="alert"
+              className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium break-keep text-red-800"
+            >
+              {submitError}
+            </div>
+          )}
 
           <div className="sticky bottom-3 z-10 flex flex-col-reverse gap-3 rounded-2xl border border-gray-200 bg-white/95 p-3 backdrop-blur sm:flex-row sm:justify-end sm:p-4">
             <Button

--- a/src/components/admin/project/ProjectForm.tsx
+++ b/src/components/admin/project/ProjectForm.tsx
@@ -3,6 +3,7 @@
 import ProjectFormBasicInfo from '@/components/admin/project/ProjectFormBasicInfo';
 import ProjectFormCategory from '@/components/admin/project/ProjectFormCategory';
 import ProjectFormDetailInfo from '@/components/admin/project/ProjectFormDetailInfo';
+import ProjectFormSection from '@/components/admin/project/ProjectFormSection';
 import ProjectFormTechnologies from '@/components/admin/project/ProjectFormTechnologies';
 import ProjectFormUrls from '@/components/admin/project/ProjectFormUrls';
 import Button from '@/components/common/Button';
@@ -113,43 +114,69 @@ export default function ProjectForm({
   };
 
   return (
-    <div className="rounded-lg bg-white p-6 shadow">
-      <h2 className="mb-6 text-2xl font-bold">
-        {editingProject ? '프로젝트 수정' : '새 프로젝트'}
-      </h2>
+    <div className="mx-auto max-w-6xl">
+      <div className="mb-6">
+        <p className="text-seagull-700 mb-2 text-sm font-semibold">
+          {editingProject ? '프로젝트 편집' : '새 프로젝트 등록'}
+        </p>
+        <h2 className="text-2xl font-bold text-gray-950 sm:text-3xl">
+          {editingProject ? editingProject.title : '프로젝트 정보를 입력하세요'}
+        </h2>
+        <p className="mt-2 text-sm leading-6 break-keep text-gray-500">
+          <span className="font-semibold text-red-600">필수</span> 항목을 먼저
+          입력하고, 영문과 상세 정보는 필요한 만큼 추가할 수 있습니다.
+        </p>
+      </div>
 
       <FormProvider {...methods}>
-        <form onSubmit={handleFormSubmit(onSubmit)} className="space-y-4">
-          <ProjectFormBasicInfo />
+        <form onSubmit={handleFormSubmit(onSubmit)} className="space-y-5">
+          <ProjectFormSection
+            eyebrow="01 · Basic"
+            title="기본 정보"
+            description="프로젝트 목록과 카드에 먼저 노출되는 핵심 정보를 입력합니다."
+          >
+            <ProjectFormBasicInfo />
+          </ProjectFormSection>
 
-          <ProjectFormTechnologies />
-
-          <ProjectFormUrls />
-
-          <ProjectFormCategory />
+          <ProjectFormSection
+            eyebrow="02 · Classification"
+            title="분류와 연결"
+            description="대표 기술, 카테고리, 저장소와 서비스 주소를 정리합니다."
+          >
+            <div className="space-y-6">
+              <ProjectFormTechnologies />
+              <div className="grid gap-5 lg:grid-cols-2">
+                <ProjectFormCategory />
+                <ProjectFormUrls />
+              </div>
+            </div>
+          </ProjectFormSection>
 
           <ProjectFormDetailInfo />
 
-          <div className="flex flex-col gap-4 sm:flex-row">
-            <Button
-              type="submit"
-              disabled={loading}
-              className="w-full sm:w-auto"
-            >
-              {loading
-                ? editingProject
-                  ? '수정 중...'
-                  : '등록 중...'
-                : editingProject
-                  ? '수정'
-                  : '등록'}
-            </Button>
+          <div className="sticky bottom-3 z-10 flex flex-col-reverse gap-3 rounded-2xl border border-gray-200 bg-white/95 p-3 backdrop-blur sm:flex-row sm:justify-end sm:p-4">
             <Button
               type="button"
               onClick={onCancel}
-              className="w-full bg-gray-500 hover:bg-gray-600 sm:w-auto"
+              disabled={loading}
+              color="linePrimary"
+              className="min-h-11 w-full sm:w-auto"
             >
               취소
+            </Button>
+            <Button
+              type="submit"
+              disabled={loading}
+              color="secondary"
+              className="min-h-11 w-full disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto sm:min-w-28"
+            >
+              {loading
+                ? editingProject
+                  ? '수정 중…'
+                  : '등록 중…'
+                : editingProject
+                  ? '수정'
+                  : '등록'}
             </Button>
           </div>
         </form>

--- a/src/components/admin/project/ProjectFormBasicInfo.tsx
+++ b/src/components/admin/project/ProjectFormBasicInfo.tsx
@@ -1,70 +1,48 @@
 'use client';
 
 import ProjectFormImageUpload from '@/components/admin/project/ProjectFormImageUpload';
-import Input from '@/components/common/Input';
-import { useFormContext } from 'react-hook-form';
+import FormField from '@/components/admin/project/FormField';
+import FormTextarea from '@/components/admin/project/FormTextarea';
 
 export default function ProjectFormBasicInfo() {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext();
-
   return (
-    <div className="space-y-4">
-      <div>
-        <label className="mb-2 block text-sm font-medium">
-          제목 <span className="text-red-500">*</span>
-        </label>
-        <Input
-          type="text"
-          {...register('title', { required: '제목을 입력해주세요.' })}
+    <div className="space-y-6">
+      <div className="grid gap-5 lg:grid-cols-2">
+        <FormField
+          name="title"
+          label="프로젝트 제목"
+          required
           placeholder="프로젝트 제목을 입력하세요"
         />
-        {errors.title && (
-          <p className="mt-1 text-xs text-red-500">
-            {String(errors.title?.message)}
-          </p>
-        )}
-      </div>
-
-      <div>
-        <label className="mb-2 block text-sm font-medium">영문 제목</label>
-        <Input
-          type="text"
-          {...register('titleEn')}
+        <FormField
+          name="titleEn"
+          label="프로젝트 제목"
+          optional
+          language="en"
           placeholder="English project title"
         />
       </div>
 
-      <div>
-        <label className="mb-2 block text-sm font-medium">
-          설명 <span className="text-red-500">*</span>
-        </label>
-        <textarea
-          {...register('description', { required: '설명을 입력해주세요.' })}
-          rows={4}
-          className="focus:border-seagull-500 w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none"
+      <div className="grid gap-5 lg:grid-cols-2">
+        <FormTextarea
+          name="description"
+          label="요약 설명"
+          required
+          rows={5}
+          placeholder="목록과 카드에 표시할 프로젝트 설명을 입력하세요"
         />
-        {errors.description && (
-          <p className="mt-1 text-xs text-red-500">
-            {String(errors.description?.message)}
-          </p>
-        )}
-      </div>
-
-      <div>
-        <label className="mb-2 block text-sm font-medium">영문 설명</label>
-        <textarea
-          {...register('descriptionEn')}
-          rows={4}
-          className="focus:border-seagull-500 w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none"
+        <FormTextarea
+          name="descriptionEn"
+          label="요약 설명"
+          optional
+          language="en"
+          rows={5}
           placeholder="English project description"
         />
       </div>
 
       <ProjectFormImageUpload
-        label="썸네일 이미지"
+        label="대표 이미지"
         fieldPath="image"
         required
         multiple={false}

--- a/src/components/admin/project/ProjectFormCategory.tsx
+++ b/src/components/admin/project/ProjectFormCategory.tsx
@@ -11,14 +11,16 @@ export default function ProjectFormCategory() {
 
   return (
     <div>
-      <label className="mb-2 block text-sm font-medium">
-        카테고리 <span className="text-red-500">*</span>
+      <label className="mb-2 flex items-center gap-2 text-sm font-semibold text-gray-800">
+        <span>카테고리</span>
+        <span className="text-xs font-medium text-red-600">필수</span>
       </label>
       <select
         {...register('category', {
           required: '카테고리를 선택해주세요.',
         })}
-        className="focus:border-seagull-500 w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none"
+        aria-invalid={Boolean(errors.category)}
+        className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 w-full rounded-xl border border-gray-300 bg-white px-4 py-2 focus:ring-2 focus:outline-none"
       >
         {PROJECT_CATEGORIES.map((category) => (
           <option key={category} value={category}>
@@ -27,7 +29,7 @@ export default function ProjectFormCategory() {
         ))}
       </select>
       {errors.category && (
-        <p className="mt-1 text-xs text-red-500">
+        <p className="mt-1.5 text-xs font-medium text-red-600" role="alert">
           {String(errors.category?.message)}
         </p>
       )}

--- a/src/components/admin/project/ProjectFormContributionsSection.tsx
+++ b/src/components/admin/project/ProjectFormContributionsSection.tsx
@@ -130,49 +130,72 @@ export default function ProjectFormContributionsSection() {
   };
 
   return (
-    <div>
-      <label className="mb-2 block text-sm font-medium">Contributions</label>
-      <div className="space-y-4">
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <Input
-            type="text"
-            value={titleInput}
-            onChange={(e) => setTitleInput(e.target.value)}
-            placeholder="기여 섹션 제목 입력"
-            className="flex-1"
-            onKeyPress={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                addContribution();
-              }
-            }}
-          />
-          <Input
-            type="text"
-            value={titleEnInput}
-            onChange={(e) => setTitleEnInput(e.target.value)}
-            placeholder="Contribution section title"
-            className="flex-1"
-          />
+    <div className="space-y-5">
+      <div className="rounded-xl bg-gray-50 p-4">
+        <div className="grid gap-3 lg:grid-cols-[1fr_1fr_auto] lg:items-end">
+          <label className="block">
+            <span className="mb-2 block text-xs font-semibold text-gray-600">
+              기여 주제
+            </span>
+            <Input
+              type="text"
+              value={titleInput}
+              onChange={(e) => setTitleInput(e.target.value)}
+              placeholder="예: 성능 최적화"
+              className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 bg-white focus:ring-2 focus:outline-none"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addContribution();
+                }
+              }}
+            />
+          </label>
+          <label className="block">
+            <span className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-gray-600">
+              Contribution title
+              <span className="rounded bg-white px-1 py-0.5 text-[9px] font-bold tracking-wide text-gray-500">
+                EN
+              </span>
+            </span>
+            <Input
+              type="text"
+              value={titleEnInput}
+              onChange={(e) => setTitleEnInput(e.target.value)}
+              placeholder="Performance optimization"
+              className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 bg-white focus:ring-2 focus:outline-none"
+            />
+          </label>
           <Button
             type="button"
             onClick={addContribution}
-            className="w-full sm:w-auto"
+            color="secondary"
+            className="min-h-11 w-full lg:w-auto"
           >
-            섹션 추가
+            주제 추가
           </Button>
         </div>
+      </div>
 
-        {contributions.map(
-          (
-            contribution: Contribution,
-            index: number
-          ) => (
-            <div
-              key={index}
-              className="space-y-2 rounded-lg border border-gray-200 bg-gray-50 p-4"
-            >
-              <div className="flex items-center gap-2">
+      {contributions.length === 0 && (
+        <div className="rounded-xl border border-dashed border-gray-300 px-4 py-7 text-center">
+          <p className="text-sm break-keep text-gray-500">
+            등록된 기여 내용이 없습니다. 먼저 기여 주제를 추가해 주세요.
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {contributions.map((contribution: Contribution, index: number) => (
+          <div
+            key={index}
+            className="space-y-4 rounded-xl border border-gray-200 p-4 sm:p-5"
+          >
+            <div className="grid gap-3 lg:grid-cols-[1fr_1fr_auto] lg:items-end">
+              <label className="block">
+                <span className="mb-1.5 block text-xs font-semibold text-gray-600">
+                  기여 주제 {index + 1}
+                </span>
                 <Input
                   type="text"
                   value={contribution.title}
@@ -180,8 +203,16 @@ export default function ProjectFormContributionsSection() {
                     updateContributionTitle(index, 'title', e.target.value)
                   }
                   placeholder="섹션 제목"
-                  className="flex-1"
+                  className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
                 />
+              </label>
+              <label className="block">
+                <span className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-gray-600">
+                  Contribution title
+                  <span className="rounded bg-gray-100 px-1 py-0.5 text-[9px] font-bold tracking-wide text-gray-500">
+                    EN
+                  </span>
+                </span>
                 <Input
                   type="text"
                   value={contribution.titleEn ?? ''}
@@ -189,130 +220,152 @@ export default function ProjectFormContributionsSection() {
                     updateContributionTitle(index, 'titleEn', e.target.value)
                   }
                   placeholder="Section title (English)"
-                  className="flex-1"
+                  className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
                 />
-                <Button
-                  type="button"
-                  onClick={() => removeContribution(index)}
-                  className="bg-red-500 hover:bg-red-600"
+              </label>
+              <Button
+                type="button"
+                onClick={() => removeContribution(index)}
+                color="danger"
+                className="min-h-11 w-full lg:w-auto"
+              >
+                주제 삭제
+              </Button>
+            </div>
+
+            <div className="space-y-3 border-t border-gray-100 pt-4">
+              <p className="text-sm font-semibold text-gray-800">세부 내용</p>
+              {contribution.details?.map((detail, detailIndex) => (
+                <div
+                  key={detailIndex}
+                  className="flex flex-col gap-3 rounded-xl bg-gray-50 p-3 sm:flex-row sm:items-start"
                 >
-                  섹션 삭제
-                </Button>
-              </div>
-
-              <div className="space-y-2 rounded bg-white p-3">
-                <label className="text-xs font-medium text-gray-600">
-                  상세 내용
-                </label>
-                {contribution.details?.map((detail, detailIndex) => (
-                  <div key={detailIndex} className="flex items-start gap-2">
-                    <div className="flex-1 space-y-1">
-                      <span className="text-sm text-gray-700">
-                        {detail.text}
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <span className="block text-sm leading-6 break-words text-gray-700">
+                      {detail.text}
+                    </span>
+                    {detail.textEn && (
+                      <span className="block text-sm leading-6 break-words text-gray-500">
+                        {detail.textEn}
                       </span>
-                      {detail.textEn && (
-                        <span className="block text-sm text-gray-500">
-                          {detail.textEn}
-                        </span>
-                      )}
-                      {detail.link && (
-                        <span className="text-xs text-blue-600">
-                          ({detail.linkText || detail.link}
-                          {detail.linkTextEn ? ` / ${detail.linkTextEn}` : ''})
-                        </span>
-                      )}
-                    </div>
-                    <Button
-                      type="button"
-                      onClick={() =>
-                        removeContributionDetail(index, detailIndex)
-                      }
-                      className="h-auto bg-red-500 px-2 py-1 text-xs hover:bg-red-600"
-                    >
-                      삭제
-                    </Button>
-                  </div>
-                ))}
-
-                <div className="mt-2 space-y-2 border-t pt-2">
-                  <Input
-                    type="text"
-                    value={detailInputs[index]?.text ?? ''}
-                    onChange={(e) =>
-                      updateContributionDetailInput(
-                        index,
-                        'text',
-                        e.target.value
-                      )
-                    }
-                    placeholder="내용 입력"
-                  />
-                  <Input
-                    type="text"
-                    value={detailInputs[index]?.textEn ?? ''}
-                    onChange={(e) =>
-                      updateContributionDetailInput(
-                        index,
-                        'textEn',
-                        e.target.value
-                      )
-                    }
-                    placeholder="Detail text in English"
-                  />
-                  <div className="flex gap-2">
-                    <Input
-                      type="url"
-                      value={detailInputs[index]?.link ?? ''}
-                      onChange={(e) =>
-                        updateContributionDetailInput(
-                          index,
-                          'link',
-                          e.target.value
-                        )
-                      }
-                      placeholder="링크 (선택)"
-                      className="flex-1"
-                    />
-                    <Input
-                      type="text"
-                      value={detailInputs[index]?.linkText ?? ''}
-                      onChange={(e) =>
-                        updateContributionDetailInput(
-                          index,
-                          'linkText',
-                          e.target.value
-                        )
-                      }
-                      placeholder="링크 텍스트"
-                      className="flex-1"
-                    />
-                    <Input
-                      type="text"
-                      value={detailInputs[index]?.linkTextEn ?? ''}
-                      onChange={(e) =>
-                        updateContributionDetailInput(
-                          index,
-                          'linkTextEn',
-                          e.target.value
-                        )
-                      }
-                      placeholder="Link text (English)"
-                      className="flex-1"
-                    />
+                    )}
+                    {detail.link && (
+                      <span className="text-seagull-700 block text-xs break-all">
+                        ({detail.linkText || detail.link}
+                        {detail.linkTextEn ? ` / ${detail.linkTextEn}` : ''})
+                      </span>
+                    )}
                   </div>
                   <Button
                     type="button"
-                    onClick={() => addContributionDetail(index)}
-                    className="w-full text-sm"
+                    onClick={() => removeContributionDetail(index, detailIndex)}
+                    color="danger"
+                    className="min-h-9 w-full px-3 py-1.5 text-xs sm:w-auto"
                   >
-                    상세 내용 추가
+                    삭제
                   </Button>
                 </div>
+              ))}
+
+              <div className="mt-2 space-y-4 rounded-xl bg-gray-50 p-3 sm:p-4">
+                <div className="grid gap-3 lg:grid-cols-2">
+                  <ContributionInput
+                    label="세부 내용"
+                    value={detailInputs[index]?.text ?? ''}
+                    onChange={(value) =>
+                      updateContributionDetailInput(index, 'text', value)
+                    }
+                    placeholder="구체적으로 기여한 내용을 입력하세요"
+                  />
+                  <ContributionInput
+                    label="Detail"
+                    language="en"
+                    value={detailInputs[index]?.textEn ?? ''}
+                    onChange={(value) =>
+                      updateContributionDetailInput(index, 'textEn', value)
+                    }
+                    placeholder="Describe your contribution in English"
+                  />
+                </div>
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                  <ContributionInput
+                    label="관련 링크"
+                    type="url"
+                    value={detailInputs[index]?.link ?? ''}
+                    onChange={(value) =>
+                      updateContributionDetailInput(index, 'link', value)
+                    }
+                    placeholder="https://..."
+                  />
+                  <ContributionInput
+                    label="링크 이름"
+                    value={detailInputs[index]?.linkText ?? ''}
+                    onChange={(value) =>
+                      updateContributionDetailInput(index, 'linkText', value)
+                    }
+                    placeholder="예: 관련 PR 보기"
+                  />
+                  <ContributionInput
+                    label="Link label"
+                    language="en"
+                    value={detailInputs[index]?.linkTextEn ?? ''}
+                    onChange={(value) =>
+                      updateContributionDetailInput(index, 'linkTextEn', value)
+                    }
+                    placeholder="View pull request"
+                  />
+                </div>
+                <Button
+                  type="button"
+                  onClick={() => addContributionDetail(index)}
+                  color="secondary"
+                  className="min-h-11 w-full text-sm sm:w-auto"
+                >
+                  세부 내용 추가
+                </Button>
               </div>
             </div>
-          )
-        )}
+          </div>
+        ))}
       </div>
     </div>
+  );
+}
+
+interface ContributionInputProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  type?: 'text' | 'url';
+  language?: 'ko' | 'en';
+}
+
+function ContributionInput({
+  label,
+  value,
+  onChange,
+  placeholder,
+  type = 'text',
+  language = 'ko',
+}: ContributionInputProps) {
+  return (
+    <label className="block">
+      <span className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-gray-600">
+        {label}
+        {language === 'en' && (
+          <span className="rounded bg-white px-1 py-0.5 text-[9px] font-bold tracking-wide text-gray-500">
+            EN
+          </span>
+        )}
+      </span>
+      <Input
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 bg-white focus:ring-2 focus:outline-none"
+      />
+    </label>
   );
 }

--- a/src/components/admin/project/ProjectFormDetailInfo.tsx
+++ b/src/components/admin/project/ProjectFormDetailInfo.tsx
@@ -4,90 +4,151 @@ import ProjectFormContributionsSection from '@/components/admin/project/ProjectF
 import ProjectFormImageUpload from '@/components/admin/project/ProjectFormImageUpload';
 import ProjectFormListSection from '@/components/admin/project/ProjectFormListSection';
 import ProjectFormOverview from '@/components/admin/project/ProjectFormOverview';
+import ProjectFormSection from '@/components/admin/project/ProjectFormSection';
 import ProjectFormTeam from '@/components/admin/project/ProjectFormTeam';
 import ProjectFormTechStackDetail from '@/components/admin/project/ProjectFormTechStackDetail';
 import ProjectFormTimeline from '@/components/admin/project/ProjectFormTimeline';
 
 export default function ProjectFormDetailInfo() {
   return (
-    <div className="mt-8 border-t pt-6">
-      <h3 className="mb-4 text-xl font-semibold">상세 정보</h3>
+    <ProjectFormSection
+      eyebrow="03 · Detail"
+      title="상세 정보"
+      description="프로젝트 상세 모달에서 보여줄 과정, 역할, 성과와 기술 정보를 입력합니다. 모든 항목은 선택 사항입니다."
+    >
+      <div className="space-y-8">
+        <DetailGroup
+          title="소개와 진행 정보"
+          description="프로젝트 개요와 작업 기간, 팀 구성을 기록합니다."
+        >
+          <div className="space-y-6">
+            <ProjectFormOverview />
+            <ProjectFormTimeline />
+            <ProjectFormTeam />
+          </div>
+        </DetailGroup>
 
-      <div className="space-y-4">
-        <ProjectFormOverview />
+        <DetailGroup
+          title="역할과 프로젝트 내용"
+          description="각 항목은 Enter 또는 추가 버튼으로 한 줄씩 등록합니다."
+        >
+          <div className="space-y-6">
+            <ListFieldPair
+              label="담당 업무"
+              englishLabel="Responsibilities"
+              fieldPath="detail.team.responsibilities"
+              englishFieldPath="detail.team.responsibilitiesEn"
+              placeholder="담당 업무 입력 후 Enter"
+              englishPlaceholder="Enter a responsibility, then press Enter"
+            />
+            <ListFieldPair
+              label="주요 기능"
+              englishLabel="Features"
+              fieldPath="detail.features"
+              englishFieldPath="detail.featuresEn"
+              placeholder="주요 기능 입력 후 Enter"
+              englishPlaceholder="Enter a feature, then press Enter"
+            />
+            <ListFieldPair
+              label="도전 과제"
+              englishLabel="Challenges"
+              fieldPath="detail.challenges"
+              englishFieldPath="detail.challengesEn"
+              placeholder="도전 과제 입력 후 Enter"
+              englishPlaceholder="Enter a challenge, then press Enter"
+            />
+            <ListFieldPair
+              label="성과"
+              englishLabel="Results"
+              fieldPath="detail.results"
+              englishFieldPath="detail.resultsEn"
+              placeholder="성과 입력 후 Enter"
+              englishPlaceholder="Enter a result, then press Enter"
+            />
+          </div>
+        </DetailGroup>
 
-        <ProjectFormTimeline />
+        <DetailGroup
+          title="기여 내용"
+          description="기여 주제 아래에 세부 내용과 관련 링크를 묶어 입력합니다."
+        >
+          <ProjectFormContributionsSection />
+        </DetailGroup>
 
-        <ProjectFormTeam />
+        <DetailGroup
+          title="기술 스택 상세"
+          description="카테고리별로 사용한 기술을 나누어 등록합니다."
+        >
+          <ProjectFormTechStackDetail />
+        </DetailGroup>
 
-        <ProjectFormListSection
-          label="Responsibilities"
-          fieldPath="detail.team.responsibilities"
-          placeholder="담당 업무 입력 후 Enter"
-          chipClassName="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-700"
-          removeButtonClassName="ml-1 text-blue-700 hover:text-blue-900"
-        />
-
-        <ProjectFormListSection
-          label="Responsibilities (English)"
-          fieldPath="detail.team.responsibilitiesEn"
-          placeholder="Enter responsibility in English, then press Enter"
-        />
-
-        <ProjectFormListSection
-          label="Features"
-          fieldPath="detail.features"
-          placeholder="기능 입력 후 Enter"
-          chipClassName="inline-flex items-center gap-1 rounded-full bg-green-100 px-3 py-1 text-sm text-green-700"
-          removeButtonClassName="ml-1 text-green-700 hover:text-green-900"
-        />
-
-        <ProjectFormListSection
-          label="Features (English)"
-          fieldPath="detail.featuresEn"
-          placeholder="Enter feature in English, then press Enter"
-        />
-
-        <ProjectFormListSection
-          label="Challenges"
-          fieldPath="detail.challenges"
-          placeholder="도전 과제 입력 후 Enter"
-          chipClassName="inline-flex items-center gap-1 rounded-full bg-red-100 px-3 py-1 text-sm text-red-700"
-          removeButtonClassName="ml-1 text-red-700 hover:text-red-900"
-        />
-
-        <ProjectFormListSection
-          label="Challenges (English)"
-          fieldPath="detail.challengesEn"
-          placeholder="Enter challenge in English, then press Enter"
-        />
-
-        <ProjectFormListSection
-          label="Results"
-          fieldPath="detail.results"
-          placeholder="결과 입력 후 Enter"
-          chipClassName="inline-flex items-center gap-1 rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-700"
-          removeButtonClassName="ml-1 text-purple-700 hover:text-purple-900"
-        />
-
-        <ProjectFormListSection
-          label="Results (English)"
-          fieldPath="detail.resultsEn"
-          placeholder="Enter result in English, then press Enter"
-        />
-
-        <ProjectFormImageUpload
-          label="상세 이미지 갤러리"
-          fieldPath="detail.images"
-          multiple
-          maxFiles={10}
-          placeholder="이미지 URL 입력 후 Enter"
-        />
-
-        <ProjectFormContributionsSection />
-
-        <ProjectFormTechStackDetail />
+        <DetailGroup
+          title="상세 이미지"
+          description="프로젝트 상세 화면에 표시할 이미지를 최대 10개까지 추가합니다."
+        >
+          <ProjectFormImageUpload
+            label="이미지 갤러리"
+            fieldPath="detail.images"
+            multiple
+            maxFiles={10}
+            placeholder="이미지 URL 입력 후 Enter"
+          />
+        </DetailGroup>
       </div>
+    </ProjectFormSection>
+  );
+}
+
+interface DetailGroupProps {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+function DetailGroup({ title, description, children }: DetailGroupProps) {
+  return (
+    <div>
+      <div className="mb-4">
+        <h4 className="font-bold text-gray-900">{title}</h4>
+        <p className="mt-1 text-sm leading-6 break-keep text-gray-500">
+          {description}
+        </p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+interface ListFieldPairProps {
+  label: string;
+  englishLabel: string;
+  fieldPath: string;
+  englishFieldPath: string;
+  placeholder: string;
+  englishPlaceholder: string;
+}
+
+function ListFieldPair({
+  label,
+  englishLabel,
+  fieldPath,
+  englishFieldPath,
+  placeholder,
+  englishPlaceholder,
+}: ListFieldPairProps) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <ProjectFormListSection
+        label={label}
+        fieldPath={fieldPath}
+        placeholder={placeholder}
+      />
+      <ProjectFormListSection
+        label={englishLabel}
+        fieldPath={englishFieldPath}
+        placeholder={englishPlaceholder}
+        language="en"
+      />
     </div>
   );
 }

--- a/src/components/admin/project/ProjectFormImageUpload.tsx
+++ b/src/components/admin/project/ProjectFormImageUpload.tsx
@@ -50,18 +50,32 @@ export default function ProjectFormImageUpload({
 
   return (
     <div>
-      <label className="mb-2 block text-sm font-medium">
-        {label} {required && <span className="text-red-500">*</span>}
-      </label>
+      <div className="mb-2 flex items-center gap-2">
+        <p className="text-sm font-semibold text-gray-800">{label}</p>
+        {required ? (
+          <span className="text-xs font-medium text-red-600">필수</span>
+        ) : (
+          <span className="text-xs font-medium text-gray-400">선택</span>
+        )}
+      </div>
+      <p className="mb-3 text-xs leading-5 break-keep text-gray-500">
+        파일을 직접 업로드하거나 외부 이미지 URL을 입력할 수 있습니다.
+      </p>
 
       {/* 업로드 방식 선택 탭 */}
-      <div className="mb-3 flex gap-2 overflow-x-auto border-b border-gray-200">
+      <div
+        className="mb-4 inline-flex rounded-xl bg-gray-100 p-1"
+        role="tablist"
+        aria-label={`${label} 입력 방식`}
+      >
         <button
           type="button"
           onClick={() => setUploadType('upload')}
-          className={`px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${
+          role="tab"
+          aria-selected={uploadType === 'upload'}
+          className={`min-h-10 rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-colors ${
             uploadType === 'upload'
-              ? 'border-seagull-500 text-seagull-600 border-b-2'
+              ? 'text-seagull-700 bg-white'
               : 'text-gray-500 hover:text-gray-700'
           }`}
         >
@@ -70,9 +84,11 @@ export default function ProjectFormImageUpload({
         <button
           type="button"
           onClick={() => setUploadType('url')}
-          className={`px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${
+          role="tab"
+          aria-selected={uploadType === 'url'}
+          className={`min-h-10 rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-colors ${
             uploadType === 'url'
-              ? 'border-seagull-500 text-seagull-600 border-b-2'
+              ? 'text-seagull-700 bg-white'
               : 'text-gray-500 hover:text-gray-700'
           }`}
         >
@@ -97,36 +113,36 @@ export default function ProjectFormImageUpload({
               value={urlInput}
               onChange={(e) => setUrlInput(e.target.value)}
               placeholder={placeholder}
-              className="flex-1"
-              onKeyPress={(e) => {
+              className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 flex-1 focus:ring-2 focus:outline-none"
+              onKeyDown={(e) => {
                 if (e.key === 'Enter') {
                   e.preventDefault();
                   handleAddUrl();
                 }
               }}
             />
-            {multiple && (
-              <Button
-                type="button"
-                onClick={handleAddUrl}
-                className="w-full sm:w-auto"
-              >
-                추가
-              </Button>
-            )}
+            <Button
+              type="button"
+              onClick={handleAddUrl}
+              color="secondary"
+              className="min-h-11 w-full sm:w-auto"
+            >
+              {multiple ? '추가' : '적용'}
+            </Button>
           </div>
           {multiple && Array.isArray(value) && value.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-2">
               {value.map((url: string, index: number) => (
                 <span
                   key={index}
-                  className="inline-flex items-center gap-1 rounded-full bg-yellow-100 px-3 py-1 text-sm text-yellow-700"
+                  className="inline-flex max-w-full items-center gap-1 rounded-lg bg-gray-100 px-3 py-1.5 text-sm text-gray-700"
                 >
                   {url.length > 40 ? `${url.substring(0, 40)}...` : url}
                   <button
                     type="button"
                     onClick={() => handleRemoveUrl(index)}
-                    className="ml-1 text-yellow-700 hover:text-yellow-900"
+                    className="ml-1 inline-flex size-6 shrink-0 items-center justify-center rounded-full text-gray-500 hover:bg-gray-200 hover:text-gray-900"
+                    aria-label={`${index + 1}번째 이미지 URL 삭제`}
                   >
                     ×
                   </button>

--- a/src/components/admin/project/ProjectFormListSection.tsx
+++ b/src/components/admin/project/ProjectFormListSection.tsx
@@ -11,6 +11,7 @@ interface ProjectFormListSectionProps {
   placeholder?: string;
   chipClassName?: string;
   removeButtonClassName?: string;
+  language?: 'ko' | 'en';
 }
 
 export default function ProjectFormListSection({
@@ -19,6 +20,7 @@ export default function ProjectFormListSection({
   placeholder = '입력 후 Enter',
   chipClassName = 'inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700',
   removeButtonClassName = 'ml-1 text-gray-700 hover:text-gray-900',
+  language = 'ko',
 }: ProjectFormListSectionProps) {
   const { watch, setValue } = useFormContext();
   const [inputValue, setInputValue] = useState('');
@@ -26,7 +28,8 @@ export default function ProjectFormListSection({
 
   const handleAdd = () => {
     if (!inputValue.trim()) return;
-    setValue(fieldPath, [...items, inputValue.trim()]);
+    if (items.includes(inputValue.trim())) return;
+    setValue(fieldPath, [...items, inputValue.trim()], { shouldDirty: true });
     setInputValue('');
   };
 
@@ -39,33 +42,47 @@ export default function ProjectFormListSection({
 
   return (
     <div>
-      <label className="mb-2 block text-sm font-medium">{label}</label>
+      <div className="mb-2 flex items-center gap-2">
+        <label className="text-sm font-semibold text-gray-800">{label}</label>
+        <span className="text-xs font-medium text-gray-400">선택</span>
+        {language === 'en' && (
+          <span className="rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-gray-500">
+            EN
+          </span>
+        )}
+      </div>
       <div className="flex flex-col gap-2 sm:flex-row">
         <Input
           type="text"
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           placeholder={placeholder}
-          className="flex-1"
-          onKeyPress={(e) => {
+          className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 flex-1 focus:ring-2 focus:outline-none"
+          onKeyDown={(e) => {
             if (e.key === 'Enter') {
               e.preventDefault();
               handleAdd();
             }
           }}
         />
-        <Button type="button" onClick={handleAdd} className="w-full sm:w-auto">
+        <Button
+          type="button"
+          onClick={handleAdd}
+          color="secondary"
+          className="min-h-11 w-full sm:w-auto"
+        >
           추가
         </Button>
       </div>
-      <div className="mt-2 flex flex-wrap gap-2">
+      <div className="mt-3 flex min-h-7 flex-wrap gap-2" aria-live="polite">
         {items.map((item: string, index: number) => (
-          <span key={index} className={chipClassName}>
-            {item}
+          <span key={index} className={`${chipClassName} max-w-full`}>
+            <span className="break-all">{item}</span>
             <button
               type="button"
               onClick={() => handleRemove(index)}
               className={removeButtonClassName}
+              aria-label={`${item} 삭제`}
             >
               ×
             </button>

--- a/src/components/admin/project/ProjectFormOverview.tsx
+++ b/src/components/admin/project/ProjectFormOverview.tsx
@@ -1,33 +1,25 @@
 'use client';
 
-import { useFormContext } from 'react-hook-form';
+import FormTextarea from '@/components/admin/project/FormTextarea';
 
 export default function ProjectFormOverview() {
-  const { register } = useFormContext();
-
   return (
-    <div className="space-y-4">
-      <div>
-        <label className="mb-2 block text-sm font-medium">Overview</label>
-        <textarea
-          {...register('detail.overview')}
-          rows={3}
-          className="focus:border-seagull-500 w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none"
-          placeholder="프로젝트 개요를 입력하세요"
-        />
-      </div>
-
-      <div>
-        <label className="mb-2 block text-sm font-medium">
-          Overview (English)
-        </label>
-        <textarea
-          {...register('detail.overviewEn')}
-          rows={3}
-          className="focus:border-seagull-500 w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none"
-          placeholder="Enter the project overview in English"
-        />
-      </div>
+    <div className="grid gap-4 lg:grid-cols-2">
+      <FormTextarea
+        name="detail.overview"
+        label="프로젝트 개요"
+        optional
+        rows={4}
+        placeholder="프로젝트의 배경과 목적을 입력하세요"
+      />
+      <FormTextarea
+        name="detail.overviewEn"
+        label="Project overview"
+        optional
+        language="en"
+        rows={4}
+        placeholder="Enter the project background and purpose"
+      />
     </div>
   );
 }

--- a/src/components/admin/project/ProjectFormSection.tsx
+++ b/src/components/admin/project/ProjectFormSection.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+
+interface ProjectFormSectionProps {
+  title: string;
+  description: string;
+  children: ReactNode;
+  eyebrow?: string;
+}
+
+export default function ProjectFormSection({
+  title,
+  description,
+  children,
+  eyebrow,
+}: ProjectFormSectionProps) {
+  return (
+    <section className="rounded-2xl border border-gray-200 bg-white p-4 sm:p-6">
+      <div className="mb-5 border-b border-gray-100 pb-4 sm:mb-6">
+        {eyebrow && (
+          <p className="text-seagull-700 mb-1 text-xs font-semibold tracking-wide uppercase">
+            {eyebrow}
+          </p>
+        )}
+        <h3 className="text-lg font-bold text-gray-950 sm:text-xl">{title}</h3>
+        <p className="mt-1 text-sm leading-6 break-keep text-gray-500">
+          {description}
+        </p>
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/src/components/admin/project/ProjectFormTeam.tsx
+++ b/src/components/admin/project/ProjectFormTeam.tsx
@@ -8,22 +8,46 @@ export default function ProjectFormTeam() {
 
   return (
     <div>
-      <label className="mb-2 block text-sm font-medium">Team</label>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="mb-2 flex items-center gap-2">
+        <p className="text-sm font-semibold text-gray-800">팀 구성</p>
+        <span className="text-xs font-medium text-gray-400">선택</span>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <div>
-          <label className="mb-1 block text-xs text-gray-600">팀 크기</label>
+          <label className="mb-1.5 block text-xs font-medium text-gray-600">
+            팀 인원
+          </label>
           <Input
             type="number"
             {...register('detail.team.size', { valueAsNumber: true })}
             placeholder="1"
+            min="1"
+            className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
           />
         </div>
         <div>
-          <label className="mb-1 block text-xs text-gray-600">역할</label>
+          <label className="mb-1.5 block text-xs font-medium text-gray-600">
+            역할
+          </label>
           <Input
             type="text"
             {...register('detail.team.role')}
             placeholder="프론트엔드 개발자"
+            className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-gray-600">
+            Role
+            <span className="rounded bg-gray-100 px-1 py-0.5 text-[9px] font-bold tracking-wide text-gray-500">
+              EN
+            </span>
+          </label>
+          <Input
+            type="text"
+            {...register('detail.team.roleEn')}
+            placeholder="Frontend developer"
+            className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
           />
         </div>
       </div>

--- a/src/components/admin/project/ProjectFormTechStackDetail.tsx
+++ b/src/components/admin/project/ProjectFormTechStackDetail.tsx
@@ -27,29 +27,30 @@ export default function ProjectFormTechStackDetail() {
   const addTechStack = () => {
     if (techStackInput.trim()) {
       const current = formData.detail?.techStack?.[techStackCategory] || [];
+      if (current.includes(techStackInput.trim())) return;
       updateTechStack(techStackCategory, [...current, techStackInput.trim()]);
       setTechStackInput('');
     }
   };
 
-  const removeTechStack = (index: number) => {
-    const current = formData.detail?.techStack?.[techStackCategory] || [];
+  const removeTechStack = (category: TechStackCategory, index: number) => {
+    const current = formData.detail?.techStack?.[category] || [];
     updateTechStack(
-      techStackCategory,
+      category,
       current.filter((_: string, i: number) => i !== index)
     );
   };
 
   return (
-    <div>
-      <label className="mb-2 block text-sm font-medium">Tech Stack</label>
-      <div className="flex flex-col gap-2 sm:flex-row">
+    <div className="space-y-4">
+      <div className="grid gap-2 sm:grid-cols-[minmax(0,12rem)_1fr_auto]">
         <select
           value={techStackCategory}
           onChange={(e) =>
             setTechStackCategory(e.target.value as TechStackCategory)
           }
-          className="focus:border-seagull-500 w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none sm:w-auto"
+          aria-label="기술 카테고리"
+          className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 w-full rounded-xl border border-gray-300 bg-white px-4 py-2 focus:ring-2 focus:outline-none"
         >
           {TECH_STACK_CATEGORIES.map((category) => (
             <option key={category.value} value={category.value}>
@@ -62,8 +63,8 @@ export default function ProjectFormTechStackDetail() {
           value={techStackInput}
           onChange={(e) => setTechStackInput(e.target.value)}
           placeholder="기술 입력 후 Enter"
-          className="flex-1"
-          onKeyPress={(e) => {
+          className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 flex-1 focus:ring-2 focus:outline-none"
+          onKeyDown={(e) => {
             if (e.key === 'Enter') {
               e.preventDefault();
               addTechStack();
@@ -73,29 +74,63 @@ export default function ProjectFormTechStackDetail() {
         <Button
           type="button"
           onClick={addTechStack}
-          className="w-full sm:w-auto"
+          color="secondary"
+          className="min-h-11 w-full sm:w-auto"
         >
           추가
         </Button>
       </div>
-      <div className="mt-2 flex flex-wrap gap-2">
-        {formData.detail?.techStack?.[techStackCategory]?.map(
-          (tech: string, index: number) => (
-            <span
-              key={index}
-              className="inline-flex items-center gap-1 rounded-full bg-indigo-100 px-3 py-1 text-sm text-indigo-700"
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {TECH_STACK_CATEGORIES.map((category) => {
+          const technologies =
+            formData.detail?.techStack?.[category.value] || [];
+
+          return (
+            <div
+              key={category.value}
+              className={`min-h-24 rounded-xl border p-3 transition-colors ${
+                techStackCategory === category.value
+                  ? 'border-seagull-200 bg-seagull-50'
+                  : 'border-gray-200 bg-gray-50'
+              }`}
             >
-              {tech}
               <button
                 type="button"
-                onClick={() => removeTechStack(index)}
-                className="ml-1 text-indigo-700 hover:text-indigo-900"
+                onClick={() => setTechStackCategory(category.value)}
+                className="focus-visible:ring-seagull-300 mb-2 flex w-full items-center justify-between rounded-lg text-left focus-visible:ring-2 focus-visible:outline-none"
               >
-                ×
+                <span className="text-sm font-semibold text-gray-800">
+                  {category.label}
+                </span>
+                <span className="rounded-full bg-white px-2 py-0.5 text-xs font-medium text-gray-500">
+                  {technologies.length}
+                </span>
               </button>
-            </span>
-          )
-        )}
+              {technologies.length === 0 ? (
+                <p className="text-xs text-gray-400">등록된 기술 없음</p>
+              ) : (
+                <div className="flex flex-wrap gap-1.5">
+                  {technologies.map((tech: string, index: number) => (
+                    <span
+                      key={`${tech}-${index}`}
+                      className="text-seagull-800 inline-flex max-w-full items-center gap-1 rounded-lg bg-white px-2.5 py-1 text-xs"
+                    >
+                      <span className="break-all">{tech}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeTechStack(category.value, index)}
+                        className="hover:text-seagull-950 inline-flex size-5 shrink-0 items-center justify-center rounded-full"
+                        aria-label={`${category.label}의 ${tech} 삭제`}
+                      >
+                        ×
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/admin/project/ProjectFormTechnologies.tsx
+++ b/src/components/admin/project/ProjectFormTechnologies.tsx
@@ -14,7 +14,10 @@ export default function ProjectFormTechnologies() {
   const addTechnology = () => {
     if (techInput.trim()) {
       const currentTechs = formData.technologies || [];
-      setValue('technologies', [...currentTechs, techInput.trim()]);
+      if (currentTechs.includes(techInput.trim())) return;
+      setValue('technologies', [...currentTechs, techInput.trim()], {
+        shouldDirty: true,
+      });
       setTechInput('');
     }
   };
@@ -29,32 +32,43 @@ export default function ProjectFormTechnologies() {
 
   return (
     <div>
-      <label className="mb-2 block text-sm font-medium">
-        기술 스택 <span className="text-red-500">*</span>
-      </label>
+      <div className="mb-2 flex items-center gap-2">
+        <label
+          htmlFor="project-technologies"
+          className="text-sm font-semibold text-gray-800"
+        >
+          대표 기술
+        </label>
+        <span className="text-xs font-medium text-red-600">필수</span>
+      </div>
+      <p className="mb-3 text-xs leading-5 break-keep text-gray-500">
+        프로젝트 카드에 표시할 핵심 기술을 입력하고 Enter 또는 추가를 누르세요.
+      </p>
       <div className="flex flex-col gap-2 sm:flex-row">
         <Input
+          id="project-technologies"
           type="text"
           value={techInput}
           onChange={(e) => setTechInput(e.target.value)}
-          onKeyPress={(e) => {
+          onKeyDown={(e) => {
             if (e.key === 'Enter') {
               e.preventDefault();
               addTechnology();
             }
           }}
           placeholder="기술 스택 입력 후 Enter"
-          className="flex-1"
+          className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 flex-1 focus:ring-2 focus:outline-none"
         />
         <Button
           type="button"
           onClick={addTechnology}
-          className="w-full sm:w-auto"
+          color="secondary"
+          className="min-h-11 w-full sm:w-auto"
         >
           추가
         </Button>
       </div>
-      <div className="mt-2 flex flex-wrap gap-2">
+      <div className="mt-3 flex min-h-7 flex-wrap gap-2" aria-live="polite">
         {formData.technologies?.map((tech: string, index: number) => (
           <span
             key={index}
@@ -64,7 +78,8 @@ export default function ProjectFormTechnologies() {
             <button
               type="button"
               onClick={() => removeTechnology(index)}
-              className="text-seagull-700 hover:text-seagull-900 ml-1"
+              className="text-seagull-700 hover:text-seagull-900 focus-visible:ring-seagull-300 ml-1 inline-flex size-6 items-center justify-center rounded-full focus-visible:ring-2 focus-visible:outline-none"
+              aria-label={`${tech} 삭제`}
             >
               ×
             </button>

--- a/src/components/admin/project/ProjectFormTimeline.tsx
+++ b/src/components/admin/project/ProjectFormTimeline.tsx
@@ -8,30 +8,42 @@ export default function ProjectFormTimeline() {
 
   return (
     <div>
-      <label className="mb-2 block text-sm font-medium">Timeline</label>
+      <div className="mb-2 flex items-center gap-2">
+        <p className="text-sm font-semibold text-gray-800">진행 기간</p>
+        <span className="text-xs font-medium text-gray-400">선택</span>
+      </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <div>
-          <label className="mb-1 block text-xs text-gray-600">시작일</label>
+          <label className="mb-1.5 block text-xs font-medium text-gray-600">
+            시작일
+          </label>
           <Input
             type="text"
             {...register('detail.timeline.startDate')}
             placeholder="2024.01"
+            className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
           />
         </div>
         <div>
-          <label className="mb-1 block text-xs text-gray-600">종료일</label>
+          <label className="mb-1.5 block text-xs font-medium text-gray-600">
+            종료일
+          </label>
           <Input
             type="text"
             {...register('detail.timeline.endDate')}
             placeholder="2024.12"
+            className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
           />
         </div>
         <div>
-          <label className="mb-1 block text-xs text-gray-600">기간</label>
+          <label className="mb-1.5 block text-xs font-medium text-gray-600">
+            기간
+          </label>
           <Input
             type="text"
             {...register('detail.timeline.duration')}
             placeholder="12개월"
+            className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
           />
         </div>
       </div>

--- a/src/components/admin/project/ProjectFormUrls.tsx
+++ b/src/components/admin/project/ProjectFormUrls.tsx
@@ -10,10 +10,11 @@ export default function ProjectFormUrls() {
   } = useFormContext();
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       <div>
-        <label className="mb-2 block text-sm font-medium">
-          GitHub URL <span className="text-red-500">*</span>
+        <label className="mb-2 flex items-center gap-2 text-sm font-semibold text-gray-800">
+          <span>GitHub URL</span>
+          <span className="text-xs font-medium text-red-600">필수</span>
         </label>
         <Input
           type="url"
@@ -21,19 +22,27 @@ export default function ProjectFormUrls() {
             required: 'GitHub URL을 입력해주세요.',
           })}
           placeholder="https://github.com/..."
+          className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
+          aria-invalid={Boolean(errors.githubUrl)}
         />
         {errors.githubUrl && (
-          <p className="mt-1 text-xs text-red-500">
+          <p className="mt-1.5 text-xs font-medium text-red-600" role="alert">
             {String(errors.githubUrl?.message)}
           </p>
         )}
       </div>
 
       <div>
-        <label className="mb-2 block text-sm font-medium">
-          Live URL (선택)
+        <label className="mb-2 flex items-center gap-2 text-sm font-semibold text-gray-800">
+          <span>Live URL</span>
+          <span className="text-xs font-medium text-gray-400">선택</span>
         </label>
-        <Input type="url" {...register('liveUrl')} placeholder="https://..." />
+        <Input
+          type="url"
+          {...register('liveUrl')}
+          placeholder="https://..."
+          className="focus:border-seagull-500 focus:ring-seagull-100 min-h-11 focus:ring-2 focus:outline-none"
+        />
       </div>
     </div>
   );

--- a/src/components/admin/project/ProjectList.tsx
+++ b/src/components/admin/project/ProjectList.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import Button from '@/components/common/Button';
 import { FirebaseProject } from '@/types';
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 interface ProjectListProps {
   onEdit: (project: FirebaseProject) => void;
@@ -11,29 +12,44 @@ interface ProjectListProps {
 export default function ProjectList({ onEdit }: ProjectListProps) {
   const [projects, setProjects] = useState<FirebaseProject[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingProjectId, setDeletingProjectId] = useState<string | null>(
+    null
+  );
+  const [actionMessage, setActionMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
 
-  useEffect(() => {
-    fetchProjects();
-  }, []);
-
-  const fetchProjects = async () => {
+  const fetchProjects = useCallback(async () => {
+    setLoading(true);
+    setError(null);
     try {
       const response = await fetch('/api/projects');
       if (response.ok) {
         const data = await response.json();
         setProjects(data);
+      } else {
+        setError('프로젝트 목록을 불러오지 못했습니다.');
       }
-    } catch (error) {
-      console.error('Error fetching projects:', error);
+    } catch {
+      setError('프로젝트 목록을 불러오는 중 오류가 발생했습니다.');
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
 
   const handleDelete = async (projectId: string, projectTitle: string) => {
     if (!confirm(`"${projectTitle}" 프로젝트를 삭제하시겠습니까?`)) {
       return;
     }
+
+    setDeletingProjectId(projectId);
+    setActionMessage(null);
 
     try {
       const response = await fetch(`/api/projects/${projectId}`, {
@@ -41,37 +57,127 @@ export default function ProjectList({ onEdit }: ProjectListProps) {
       });
 
       if (response.ok) {
-        alert('프로젝트가 삭제되었습니다.');
-        fetchProjects(); // 목록 새로고침
+        setProjects((currentProjects) =>
+          currentProjects.filter((project) => project.id !== projectId)
+        );
+        setActionMessage({
+          type: 'success',
+          text: `“${projectTitle}” 프로젝트를 삭제했습니다.`,
+        });
       } else {
-        alert('프로젝트 삭제에 실패했습니다.');
+        setActionMessage({
+          type: 'error',
+          text: '프로젝트 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.',
+        });
       }
-    } catch (error) {
-      console.error('Error deleting project:', error);
-      alert('프로젝트 삭제 중 오류가 발생했습니다.');
+    } catch {
+      setActionMessage({
+        type: 'error',
+        text: '프로젝트 삭제 중 오류가 발생했습니다.',
+      });
+    } finally {
+      setDeletingProjectId(null);
     }
   };
 
   if (loading) {
-    return <div className="text-center">로딩 중...</div>;
+    return (
+      <div
+        className="space-y-4"
+        aria-busy="true"
+        aria-label="프로젝트 목록 로딩 중"
+      >
+        <p className="sr-only">프로젝트 목록을 불러오는 중입니다.</p>
+        {[0, 1, 2].map((item) => (
+          <div
+            key={item}
+            className="animate-pulse rounded-2xl border border-gray-200 bg-white p-4 sm:p-5"
+          >
+            <div className="flex gap-4">
+              <div className="size-20 shrink-0 rounded-xl bg-gray-200 sm:size-24" />
+              <div className="flex-1 space-y-3 py-1">
+                <div className="h-5 w-2/5 rounded bg-gray-200" />
+                <div className="h-4 w-full rounded bg-gray-100" />
+                <div className="h-4 w-3/4 rounded bg-gray-100" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-200 bg-red-50 px-5 py-10 text-center">
+        <p className="font-semibold text-red-800">목록을 표시할 수 없습니다</p>
+        <p className="mt-2 text-sm break-keep text-red-700">{error}</p>
+        <Button
+          type="button"
+          onClick={fetchProjects}
+          color="danger"
+          className="mt-5 min-h-11"
+        >
+          다시 시도
+        </Button>
+      </div>
+    );
   }
 
   if (projects.length === 0) {
     return (
-      <div className="rounded-lg bg-white p-12 text-center shadow">
-        <p className="text-gray-500">등록된 프로젝트가 없습니다.</p>
+      <div className="rounded-2xl border border-dashed border-gray-300 bg-white px-5 py-14 text-center">
+        <div className="mx-auto flex size-12 items-center justify-center rounded-2xl bg-gray-100 text-2xl text-gray-400">
+          +
+        </div>
+        <p className="mt-4 font-semibold text-gray-900">
+          등록된 프로젝트가 없습니다
+        </p>
+        <p className="mt-2 text-sm leading-6 break-keep text-gray-500">
+          상단의 새 프로젝트 버튼을 눌러 첫 프로젝트를 등록해 보세요.
+        </p>
       </div>
     );
   }
 
   return (
     <div className="space-y-4">
+      {actionMessage && (
+        <div
+          role="status"
+          className={`rounded-xl border px-4 py-3 text-sm font-medium break-keep ${
+            actionMessage.type === 'success'
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+              : 'border-red-200 bg-red-50 text-red-800'
+          }`}
+        >
+          {actionMessage.text}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-3 px-1">
+        <p className="text-sm text-gray-500">
+          총{' '}
+          <span className="font-semibold text-gray-900">{projects.length}</span>
+          개
+        </p>
+        <Button
+          type="button"
+          onClick={fetchProjects}
+          color="linePrimary"
+          size="small"
+          className="min-h-10"
+        >
+          목록 새로고침
+        </Button>
+      </div>
+
       {projects.map((project) => (
         <div
           key={project.id}
-          className="flex items-center gap-4 rounded-lg bg-white p-4 shadow"
+          className="flex flex-col gap-4 rounded-2xl border border-gray-200 bg-white p-4 sm:flex-row sm:items-center sm:p-5"
         >
-          <div className="relative h-20 w-20 overflow-hidden rounded-lg">
+          <div className="relative aspect-video w-full shrink-0 overflow-hidden rounded-xl bg-gray-100 sm:aspect-square sm:size-24">
             <Image
               src={project.image || '/images/common/img_user.png'}
               alt={project.title}
@@ -79,24 +185,41 @@ export default function ProjectList({ onEdit }: ProjectListProps) {
               className="object-cover"
             />
           </div>
-          <div className="flex-1">
-            <h3 className="text-lg font-semibold">{project.title}</h3>
-            <p className="text-sm text-gray-600">{project.description}</p>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="line-clamp-2 text-lg font-bold break-words text-gray-950">
+                {project.title}
+              </h3>
+              <span className="rounded-lg bg-gray-100 px-2 py-1 text-xs font-medium break-all text-gray-600">
+                {project.category}
+              </span>
+            </div>
+            <p className="mt-1 line-clamp-2 text-sm leading-6 break-words text-gray-600">
+              {project.description}
+            </p>
             <div className="mt-2 flex flex-wrap gap-2">
-              {project.technologies?.map((tech: string, index: number) => (
-                <span
-                  key={index}
-                  className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700"
-                >
-                  {tech}
+              {project.technologies
+                ?.slice(0, 5)
+                .map((tech: string, index: number) => (
+                  <span
+                    key={index}
+                    className="max-w-full rounded-lg bg-gray-100 px-2 py-1 text-xs break-all text-gray-700"
+                  >
+                    {tech}
+                  </span>
+                ))}
+              {(project.technologies?.length || 0) > 5 && (
+                <span className="rounded-lg bg-gray-100 px-2 py-1 text-xs text-gray-500">
+                  +{project.technologies.length - 5}
                 </span>
-              ))}
+              )}
             </div>
           </div>
-          <div className="flex gap-2">
+          <div className="grid shrink-0 grid-cols-2 gap-2 sm:flex">
             <button
               onClick={() => onEdit(project)}
-              className="bg-seagull-500 hover:bg-seagull-600 rounded-lg px-4 py-2 text-white transition"
+              disabled={deletingProjectId === project.id}
+              className="bg-seagull-500 hover:bg-seagull-600 focus-visible:ring-seagull-200 min-h-11 rounded-xl px-4 py-2 text-sm font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             >
               수정
             </button>
@@ -104,9 +227,10 @@ export default function ProjectList({ onEdit }: ProjectListProps) {
               onClick={() =>
                 project.id && handleDelete(project.id, project.title)
               }
-              className="rounded-lg bg-red-500 px-4 py-2 text-white transition hover:bg-red-600"
+              disabled={deletingProjectId === project.id}
+              className="min-h-11 rounded-xl bg-red-50 px-4 py-2 text-sm font-semibold text-red-700 transition-colors hover:bg-red-100 focus-visible:ring-2 focus-visible:ring-red-200 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             >
-              삭제
+              {deletingProjectId === project.id ? '삭제 중…' : '삭제'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## 관련 이슈

- Closes #77
- Related to #74

## 변경 사항

- [ ] 버그 수정
- [ ] 신규 기능
- [x] 기존 기능 개선
- [ ] 리팩토링
- [ ] 문서 업데이트
- [x] UI 변경
- [ ] 기타

## 상세 설명

- 관리자 프로젝트 폼을 기본 정보, 분류와 연결, 상세 정보 섹션으로 재구성했습니다.
- 필수/선택/영문 필드 표기와 한영 입력 배치, 이미지 업로드/URL 입력 흐름을 개선했습니다.
- Overview, Timeline, Team, 목록형 상세 정보, Contributions, 기술 스택 상세 입력의 스캔성과 모바일 사용성을 개선했습니다.
- 프로젝트 목록에 로딩 스켈레톤, 오류 재시도, 빈 상태, 삭제 진행 및 성공/실패 피드백을 추가했습니다.
- 기존 create/update/delete API와 데이터 저장 구조는 유지했습니다.

## UI 확인

- [ ] 변경된 UI 스크린샷 또는 GIF 첨부
- [x] 모바일/데스크톱 레이아웃 확인
- [x] 한국어/영어 텍스트 줄바꿈 확인
- [x] 접근성 라벨 및 포커스 상태 확인

## 검증

- [x] `git status -sb`
- [x] `npx tsc --noEmit`
- [x] targeted `npx eslint ...`
- [ ] `npm run build`
- [ ] 해당 없음

## AI-Assisted

- [x] Yes
- [ ] No

## 비고

- Codex가 구현, 검증, PR 초안을 지원했습니다.
- 기본 Turbopack 빌드는 Windows 심볼릭 링크 권한 오류(`firebase-admin`, os error 1314)로 중단됐습니다.
- 대체 검증인 `npx next build --webpack`은 컴파일, 타입 검사, 35개 정적 페이지 생성까지 통과했습니다.